### PR TITLE
micro-optimization: ast.parse(..., mode='single') is faster

### DIFF
--- a/classify_imports.py
+++ b/classify_imports.py
@@ -271,7 +271,7 @@ _import_type = {ast.Import: Import, ast.ImportFrom: ImportFrom}
 
 @functools.lru_cache(maxsize=None)
 def import_obj_from_str(s: str) -> Import | ImportFrom:
-    node = ast.parse(s).body[0]
+    node = ast.parse(s, mode='single').body[0]
     return _import_type[type(node)](node)
 
 


### PR DESCRIPTION
doubt it makes much of a difference:

```pycon
>>> timeit.timeit('ast.parse("import x")', globals={'ast': ast})
3.352381504002551
>>> timeit.timeit('ast.parse("import x", mode="single")', globals={'ast': ast})
2.8154837469992344
```