### PR TITLE
Standardize handling of builtin imports between Python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,pypy3,pre-commit
+envlist = py37,py38,py39,py310,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
In Python 3.10+, we have access to [`sys.stdlib_module_names`](https://docs.python.org/3.10/library/sys.html#sys.stdlib_module_names), which lets us know all of the modules that are considered part of the Python stdlib — regardless of whether they are compiled into the current Python interpreter.

In earlier versions of Python 3, we have only [`sys.builtin_module_names`](https://docs.python.org/3.10/library/sys.html#sys.builtin_module_names), which tells us the modules that are compiled into the current interpreter.

To work around this, we need a solution to tell us whether a module that is not compiled into the current interpreter should be considered part of the stdlib. The previous approach considered all paths inside `sys.path`, excluding those ending with `-packages` (to exclude `site-packages` and `dist-packages`), to contain only stdlib modules. We also excluded the paths found in the `PYTHONPATH` environment variable, reasoning that if a path was present in `sys.path` because it was added by `PYTHONPATH`, it was a path falling outside the default Python interpreter paths. If we found the module in question within one of these paths, we'd report it as a builtin.

With this change, we instead use [`distutils.sysconfig.get_python_lib(standard_lib=True)`](https://docs.python.org/3.10/distutils/apiref.html?highlight=sysconfig%20get_python_lib#distutils.sysconfig.get_python_lib), which directly reports the path used for the standard library (and not third-party extensions).

Finally, we're making the order of resolution consistent among Python versions. We check, in priority order:
1. If the module is specified in `unclassifiable_application_modules` (this is our "manual override")
1. If the module is in the list of known builtins
1. If the module can be found in the application path, influenced by the `application_directories` setting
1. If the module can be found in the standard library path If none of the above match, we assume the import is a third-party module.

Under Python 3.10+, we expect that check 4 never matches without check 2 having matched first.

All of this also allows us to reduce much of the code duplication introduced in bdc924875711a6f7a9239cec92f9cafe4c3ba657.

Tests are updated to reflect these new cases, and `tox.ini` adds all the interpreter versions we care about. We're also able to remove a previous version-specific test skip that was necessary due to the version-inconsistent behavior, but no longer performs differently among versions.

Fixes #155.